### PR TITLE
APIGateway.Request Version 1 Support

### DIFF
--- a/Sources/MacroLambdaCore/LambdaResponse.swift
+++ b/Sources/MacroLambdaCore/LambdaResponse.swift
@@ -42,6 +42,35 @@ extension ServerResponse {
                  isBase64Encoded   : body != nil ? true : false,
                  cookies           : cookies)
   }
+  
+  var asLambdaV1GatewayResponse: APIGateway.Response {
+    assert(writableEnded, "sending ServerResponse which didn't end?!")
+    
+    let ( singleHeaders, multiHeaders, _ ) = headers.asLambda()
+    
+    let body : String? = {
+      guard let writtenContent = writableBuffer, !writtenContent.isEmpty else {
+        return nil
+      }
+      
+      // TBD: We could make this more tolerant and use a String if the content
+      //      is textual and can be converted to UTF-8? Would make it faster as
+      //      well.
+      do {
+        return try writtenContent.toString("base64")
+      }
+      catch { // FIXME: make throwing
+        log.error("could not convert body to base64: \(error)")
+        return nil
+      }
+    }()
+    
+    return .init(statusCode        : status.asLambda,
+                 headers           : singleHeaders,
+                 multiValueHeaders : multiHeaders,
+                 body              : body,
+                 isBase64Encoded   : body != nil ? true : false)
+  }
 }
 
 #endif // canImport(AWSLambdaEvents)

--- a/Sources/MacroLambdaCore/LambdaServer.swift
+++ b/Sources/MacroLambdaCore/LambdaServer.swift
@@ -208,8 +208,10 @@ extension lambda {
           return promise.futureResult
         }
       }
-        
-      let proxy = APIGatewayV1ProxyLambda(server: self)
+      
+      // FIXME: This proxy is where the Lambda Request payload type is determined for Codable decoding.
+      //        Need to figure out how to select or determine type.
+      let proxy = APIGatewayProxyLambda(server: self)
       Lambda.run(proxy)
       Foundation.exit(0) // Because `run` is not marked as Never (Issue #151)
     }

--- a/Sources/MacroLambdaCore/LambdaServer.swift
+++ b/Sources/MacroLambdaCore/LambdaServer.swift
@@ -180,8 +180,6 @@ extension lambda {
       struct APIGatewayProxyLambda: EventLoopLambdaHandler {
         typealias In  = APIGateway.V2.Request
         typealias Out = APIGateway.V2.Response
-        typealias InV1  = APIGateway.Request
-        typealias OutV1 = APIGateway.Response
         
         let server : Server
 
@@ -193,17 +191,25 @@ extension lambda {
           }
           return promise.futureResult
         }
+      }
+      
+      struct APIGatewayV1ProxyLambda: EventLoopLambdaHandler {
+        typealias In  = APIGateway.Request
+        typealias Out = APIGateway.Response
         
-        func handle(context: Lambda.Context, event: InV1) -> EventLoopFuture<OutV1>
+        let server : Server
+
+        func handle(context: Lambda.Context, event: In) -> EventLoopFuture<Out>
         {
-          let promise = context.eventLoop.makePromise(of: OutV1.self)
+          let promise = context.eventLoop.makePromise(of: Out.self)
           server.handle(context: context, request: event) { result in
             promise.completeWith(result)
           }
           return promise.futureResult
         }
       }
-      let proxy = APIGatewayProxyLambda(server: self)
+        
+      let proxy = APIGatewayV1ProxyLambda(server: self)
       Lambda.run(proxy)
       Foundation.exit(0) // Because `run` is not marked as Never (Issue #151)
     }


### PR DESCRIPTION
Overloaded functions to support APIGateway.Request V1. Duplicated variables for V1 support.

WIP - LambdaServer.swift has a FIXME note that identifies that the proxy is where the Lambda Request payload type is determined for Codable decoding. Need to figure out how to select or determine type.